### PR TITLE
Add `terraform-ansible-vagrant-ansible` for deploying with nested virtualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,15 @@
 admin.conf
 
 # Ignore kubeadm files
-ansible-playbooks/join-command
-ansible-playbooks/join-command-master
+join-command
+join-command-master
 
 # Ignore DS_store
 .DS_Store
+
+# Intellij products
+.idea
+
+# Terraform
+.terraform*
+terraform.tfstate*

--- a/terraform-ansible-vagrant-ansible/README.md
+++ b/terraform-ansible-vagrant-ansible/README.md
@@ -1,0 +1,31 @@
+# terraform-ansible-vagrant-ansible
+
+This folder contains the source code for deploying Kubernetes on Google Cloud platform with the following properties:
+
+* Terraform is used to deploy a Single VM
+* A local terraform provisioner (Ansible: `ansible-system/system-create-playbook.yaml`) is called when the system is ready
+* That playbook:
+  * installs qemu, libvirt, Vagrant, and Ansible
+  * copies Vagrantfile and ansible playbooks to a temporary directory
+  * spins up a Vagrant based deployment as described in [../README.md](../README.md) 
+
+## How to use?
+
+* Install `google cloud sdk`
+* Authenticate with `gcloud auth application-default login`
+* In the `terraform` directory:
+  * run `terraform init`
+  * update the `variables.tf` (or update them from your environment variables TF_VAR_...)
+  * run `terraform apply` and accept changes
+
+It takes about ~15 minutes to fully deploy the cluster using this method.
+
+## Debugging
+
+### Connecting to the VM
+
+`gcloud compute ssh --zone "europe-west4-a" "terraform-ansible-vagrant-ansible"  --project "bsc-jop-zitman"`
+
+### Running Ansible manually
+
+`ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook  -v -u 'endpositive' -i '12.34.56.78,' --private-key ~/.ssh/google_compute_engine -e 'pub_key=~/.ssh/google_compute_engine.pub' ../ansible-system/system-create-playbook.yaml`

--- a/terraform-ansible-vagrant-ansible/Vagrantfile
+++ b/terraform-ansible-vagrant-ansible/Vagrantfile
@@ -1,0 +1,1 @@
+../Vagrantfile

--- a/terraform-ansible-vagrant-ansible/ansible-kubernetes
+++ b/terraform-ansible-vagrant-ansible/ansible-kubernetes
@@ -1,0 +1,1 @@
+../ansible-playbooks

--- a/terraform-ansible-vagrant-ansible/ansible-system/system-create-playbook.yaml
+++ b/terraform-ansible-vagrant-ansible/ansible-system/system-create-playbook.yaml
@@ -1,0 +1,88 @@
+- hosts: all
+  become: true
+  vars:
+    PROVISION_DIR: /tmp/provision
+  tasks:
+    - name: Add an apt signing key for Hashicorp repo
+      apt_key:
+        url: https://apt.releases.hashicorp.com/gpg
+        state: present
+
+    - name: Add Hashicorp apt repository
+      apt_repository:
+        repo: deb [arch=amd64] https://apt.releases.hashicorp.com focal main
+        state: present
+
+    - name: Add Ansible PPA
+      apt_repository:
+        repo: 'ppa:ansible/ansible'
+        state: present
+
+    - name: Enable source repositories
+      replace:
+        path: /etc/apt/sources.list
+        regexp: '^#(.*deb-src.*)$'
+        replace: '\1'
+
+
+    - name: Install build dependencies for Vagrant libvirt
+      apt:
+        name: "{{ packages }}"
+        state: build-dep
+        update_cache: yes
+      vars:
+        packages:
+          - vagrant
+          - ruby-libvirt
+
+    - name: Install Vagrant libvirt dependencies
+      apt:
+        name: "{{ packages }}"
+        state: present
+        update_cache: yes
+      vars:
+        packages:
+          - vagrant
+          - qemu
+          - libvirt-daemon-system
+          - libvirt-clients
+          - ebtables
+          - dnsmasq-base
+          - libxslt-dev
+          - libxml2-dev
+          - libvirt-dev
+          - zlib1g-dev
+          - ruby-dev
+          - libguestfs-tools
+
+    - name: Install vagrant-libvirt plugin
+      command: vagrant plugin install vagrant-libvirt
+
+    - name: Install Ansible
+      apt:
+        name: "{{ packages }}"
+        state: present
+        update_cache: yes
+      vars:
+        packages:
+          - ansible
+
+    - name: Create temporary provision directory
+      file:
+        path: "{{ PROVISION_DIR }}"
+        state: directory
+
+    - name: Copy Vagrantfile
+      copy:
+        src: ../Vagrantfile
+        dest: "{{ PROVISION_DIR }}/Vagrantfile"
+
+    - name: Copy Kubernetes Ansible Playbook
+      copy:
+        src: ../ansible-kubernetes/
+        dest: "{{ PROVISION_DIR }}/ansible-playbooks/"
+
+    - name: Boot remote Kubernetes VMs
+      command:
+        chdir: "{{ PROVISION_DIR }}"
+        cmd: vagrant up

--- a/terraform-ansible-vagrant-ansible/ansible-system/system-destroy-playbook.yaml
+++ b/terraform-ansible-vagrant-ansible/ansible-system/system-destroy-playbook.yaml
@@ -1,0 +1,9 @@
+- hosts: all
+  become: true
+  vars:
+    PROVISION_DIR: /tmp/provision
+  tasks:
+    - name: Reset remote Vagrant state
+      command:
+        chdir: "{{ PROVISION_DIR }}"
+        cmd: vagrant destroy --force

--- a/terraform-ansible-vagrant-ansible/terraform/main.tf
+++ b/terraform-ansible-vagrant-ansible/terraform/main.tf
@@ -29,26 +29,8 @@ resource "google_compute_instance" "terraform-ansible-vagrant-ansible" {
       private_key = file("~/.ssh/google_compute_engine")
     }
   }
-}
-
-# Provisioning on a separate
-resource "null_resource" "terraform-ansible-vagrant-ansible" {
-  depends_on = [google_compute_instance.terraform-ansible-vagrant-ansible]
-
-  triggers = {
-    ssh_username    = var.ssh_username
-    ssh_key_public  = var.ssh_key_public
-    ssh_key_private = var.ssh_key_private
-    nat_ip          = google_compute_instance.terraform-ansible-vagrant-ansible.network_interface[0].access_config[0].nat_ip
-  }
 
   provisioner "local-exec" {
-    when    = create
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${self.triggers.ssh_username}' -i '${self.triggers.nat_ip},' --private-key ${self.triggers.ssh_key_private} -e 'pub_key=${self.triggers.ssh_key_public}' ../ansible-system/system-create-playbook.yaml"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${self.triggers.ssh_username}' -i '${self.triggers.nat_ip},' --private-key ${self.triggers.ssh_key_private} -e 'pub_key=${self.triggers.ssh_key_public}' ../ansible-system/system-destroy-playbook.yaml"
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${var.ssh_username}' -i '${self.network_interface[0].access_config[0].nat_ip},' --private-key ${var.ssh_key_private} -e 'pub_key=${var.ssh_key_public}' ../ansible-system/system-create-playbook.yaml"
   }
 }

--- a/terraform-ansible-vagrant-ansible/terraform/main.tf
+++ b/terraform-ansible-vagrant-ansible/terraform/main.tf
@@ -1,0 +1,54 @@
+resource "google_compute_instance" "terraform-ansible-vagrant-ansible" {
+  name = "terraform-ansible-vagrant-ansible"
+
+  # Enable VT-x
+  machine_type = "n2-highcpu-8"
+  advanced_machine_features {
+    enable_nested_virtualization = true
+  }
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size
+      image = "ubuntu-2004-focal-v20220404"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  provisioner "remote-exec" {
+    inline = ["echo 'VM up and running!'"]
+
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      user        = var.ssh_username
+      private_key = file("~/.ssh/google_compute_engine")
+    }
+  }
+}
+
+# Provisioning on a separate
+resource "null_resource" "terraform-ansible-vagrant-ansible" {
+  depends_on = [google_compute_instance.terraform-ansible-vagrant-ansible]
+
+  triggers = {
+    ssh_username    = var.ssh_username
+    ssh_key_public  = var.ssh_key_public
+    ssh_key_private = var.ssh_key_private
+    nat_ip          = google_compute_instance.terraform-ansible-vagrant-ansible.network_interface[0].access_config[0].nat_ip
+  }
+
+  provisioner "local-exec" {
+    when    = create
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${self.triggers.ssh_username}' -i '${self.triggers.nat_ip},' --private-key ${self.triggers.ssh_key_private} -e 'pub_key=${self.triggers.ssh_key_public}' ../ansible-system/system-create-playbook.yaml"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${self.triggers.ssh_username}' -i '${self.triggers.nat_ip},' --private-key ${self.triggers.ssh_key_private} -e 'pub_key=${self.triggers.ssh_key_public}' ../ansible-system/system-destroy-playbook.yaml"
+  }
+}

--- a/terraform-ansible-vagrant-ansible/terraform/provider.tf
+++ b/terraform-ansible-vagrant-ansible/terraform/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project = var.project
+  region = var.region
+  zone = var.zone
+}

--- a/terraform-ansible-vagrant-ansible/terraform/variables.tf
+++ b/terraform-ansible-vagrant-ansible/terraform/variables.tf
@@ -1,0 +1,25 @@
+variable "project" {
+  default = "bsc-jop-zitman"
+}
+
+variable "region" {
+  default = "europe-west4"
+}
+
+variable "zone" {
+  default = "europe-west4-a"
+}
+
+variable "boot_disk_size" {
+  default = "100"
+}
+
+variable "ssh_username" {}
+
+variable "ssh_key_private" {
+  default = "~/.ssh/google_compute_engine"
+}
+
+variable "ssh_key_public" {
+  default = "~/.ssh/google_compute_engine.pub"
+}


### PR DESCRIPTION
Deploys the Kubernetes testbed on a single GCP VM with nested virtualization (Vagrant + libvirt).