### PR TITLE
Add `terraform-ansible`

### DIFF
--- a/terraform-ansible/README.md
+++ b/terraform-ansible/README.md
@@ -1,0 +1,28 @@
+# terraform-ansible
+
+This folder contains the source code for deploying Kubernetes on Google Cloud platform with the following properties:
+
+* Terraform is used to deploy multiple VMs (mimicking Vagrant)
+* Ansible playbooks are called based for each type of node (master, master-replica, worker, load balancer)
+
+## How to use?
+
+* Install `google cloud sdk`
+* Authenticate with `gcloud auth application-default login`
+* In the `terraform` directory:
+    * run `terraform init`
+    * update the `variables.tf` (or update them from your environment variables TF_VAR_...)
+    * run `terraform apply` and accept changes
+
+It takes about ~5 minutes to fully deploy the cluster using this method.
+
+## Debugging
+
+### Connecting to the VM
+
+`gcloud compute ssh --zone "europe-west4-a" "terraform-ansible-master-1"  --project "bsc-jop-zitman"`
+
+### Running Ansible manually
+
+If ansible fails, please check the Terraform output for the ansible command.
+The command contains lots of dynamic values that you don't want to determine manually.

--- a/terraform-ansible/ansible-kubernetes
+++ b/terraform-ansible/ansible-kubernetes
@@ -1,0 +1,1 @@
+../ansible-playbooks

--- a/terraform-ansible/terraform/main.tf
+++ b/terraform-ansible/terraform/main.tf
@@ -1,0 +1,154 @@
+resource "google_compute_instance" "terraform-ansible-load-balancer" {
+  count    = var.n_m_nodes > 1 ? 1 : 0
+  name     = "terraform-ansible-load-balancer"
+  hostname = "load-balancer.internal"
+
+  machine_type = var.machine_type_load_balancer
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size
+      image = var.image_name
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  can_ip_forward = true
+
+  provisioner "remote-exec" {
+    inline = ["echo 'VM up and running!'"]
+
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      user        = var.ssh_username
+      private_key = file("~/.ssh/google_compute_engine")
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${var.ssh_username}' -i '${self.network_interface[0].access_config[0].nat_ip},' --private-key ${var.ssh_key_private}  -e 'user=${var.ssh_username} n_m_nodes=${var.n_m_nodes} n_w_nodes=${var.n_w_nodes} hostname=${self.hostname} node_ip=${self.network_interface[0].network_ip} c_eng=${var.c_eng} cni=${var.cni}' ../ansible-kubernetes/master-playbook.yml"
+  }
+}
+
+resource "google_compute_instance" "terraform-ansible-master" {
+  depends_on = [google_compute_instance.terraform-ansible-load-balancer]
+
+  name     = "terraform-ansible-master-1"
+  hostname = "master-node-1.internal"
+
+  machine_type = var.machine_type_master
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size
+      image = var.image_name
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  can_ip_forward = true
+
+  provisioner "remote-exec" {
+    inline = ["echo 'VM up and running!'"]
+
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      user        = var.ssh_username
+      private_key = file("~/.ssh/google_compute_engine")
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${var.ssh_username}' -i '${self.network_interface[0].access_config[0].nat_ip},' --private-key ${var.ssh_key_private} -e 'user=${var.ssh_username} n_m_nodes=${var.n_m_nodes} n_w_nodes=${var.n_w_nodes} hostname=${self.hostname} node_ip=${self.network_interface[0].network_ip} c_eng=${var.c_eng} cni=${var.cni}' ../ansible-kubernetes/master-playbook.yml"
+  }
+}
+
+resource "google_compute_instance" "terraform-ansible-master-replica" {
+  count      = var.n_m_nodes > 1 ? var.n_m_nodes - 1 : 0
+  depends_on = [
+    google_compute_instance.terraform-ansible-load-balancer, google_compute_instance.terraform-ansible-master
+  ]
+
+  name     = "terraform-ansible-master-${count.index + 2}"
+  hostname = "master-node-${count.index + 2}.internal"
+
+  machine_type = var.machine_type_master_replica
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size
+      image = var.image_name
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  can_ip_forward = true
+
+  provisioner "remote-exec" {
+    inline = ["echo 'VM up and running!'"]
+
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      user        = var.ssh_username
+      private_key = file("~/.ssh/google_compute_engine")
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${var.ssh_username}' -i '${self.network_interface[0].access_config[0].nat_ip},' --private-key ${var.ssh_key_private} -e 'user=${var.ssh_username} n_m_nodes=${var.n_m_nodes} n_w_nodes=${var.n_w_nodes} hostname=${self.hostname} node_ip=${self.network_interface[0].network_ip} c_eng=${var.c_eng} cni=${var.cni}' ../ansible-kubernetes/master-replica-playbook.yml"
+  }
+}
+
+resource "google_compute_instance" "terraform-ansible-worker" {
+  count      = var.n_w_nodes
+  depends_on = [
+    google_compute_instance.terraform-ansible-load-balancer, google_compute_instance.terraform-ansible-master
+  ]
+
+  name     = "terraform-ansible-worker-${count.index + 1}"
+  hostname = "worker-node-${count.index + 1}.internal"
+
+  machine_type = var.machine_type_worker
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size
+      image = var.image_name
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  provisioner "remote-exec" {
+    inline = ["echo 'VM up and running!'"]
+
+    connection {
+      host        = self.network_interface[0].access_config[0].nat_ip
+      type        = "ssh"
+      user        = var.ssh_username
+      private_key = file("~/.ssh/google_compute_engine")
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -v -u '${var.ssh_username}' -i '${self.network_interface[0].access_config[0].nat_ip},' --private-key ${var.ssh_key_private} -e 'user=${var.ssh_username} hostname=${self.hostname} node_ip=${self.network_interface[0].network_ip} c_eng=${var.c_eng} cni=${var.cni}' ../ansible-kubernetes/worker-node.yml"
+  }
+}

--- a/terraform-ansible/terraform/provider.tf
+++ b/terraform-ansible/terraform/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project = var.project
+  region = var.region
+  zone = var.zone
+}

--- a/terraform-ansible/terraform/variables.tf
+++ b/terraform-ansible/terraform/variables.tf
@@ -1,0 +1,70 @@
+variable "project" {
+  default = "bsc-jop-zitman"
+}
+
+variable "region" {
+  default = "europe-west4"
+}
+
+variable "zone" {
+  default = "europe-west4-a"
+}
+
+variable "boot_disk_size" {
+  default = "100"
+}
+
+variable "ssh_username" {}
+
+variable "ssh_key_private" {
+  default = "~/.ssh/google_compute_engine"
+}
+
+variable "ssh_key_public" {
+  default = "~/.ssh/google_compute_engine.pub"
+}
+
+variable "image_name" {
+  description = "Ubuntu server image"
+  default = "ubuntu-2004-focal-v20220404"
+}
+
+variable "machine_type" {
+  default = "n2-highcpu-2"
+}
+
+variable "n_m_nodes" {
+  description = "Number of master nodes"
+  default = 1
+}
+
+variable "n_w_nodes" {
+  description = "Number of workers nodes (should be at maximum 9)"
+  default = 1
+}
+
+variable "c_eng" {
+  description = "Container RunTime Engine selection, Docker=1, containerd=2, CRI-O=3"
+  default = 1
+}
+
+variable "cni" {
+  description = "CNI Network Plugin selection. Calico=1, Cilium=2, Weave=3, Flannel=4"
+  default = 1
+}
+
+variable "machine_type_load_balancer" {
+  default = "n2-highcpu-2"
+}
+
+variable "machine_type_master" {
+  default = "n2-highcpu-2"
+}
+
+variable "machine_type_master_replica" {
+  default = "n2-highcpu-2"
+}
+
+variable "machine_type_worker" {
+  default = "n2-highcpu-2"
+}


### PR DESCRIPTION
Deploys the Kubernetes testbed on multiple GCP VMs.

TODO:
* [ ] Test multi worker setup
* [ ] Test multi master setup (I expect some difficulties with hardcoded lb IPs)
* [ ] Refactor not-so-DRY code in `main.tf`

Depends on:
* [ ] assuremoss/Kubernetes-testbed#6
* [ ] assuremoss/Kubernetes-testbed#7